### PR TITLE
Fix a syntax error in main.js

### DIFF
--- a/responses/07_add-input-params.md
+++ b/responses/07_add-input-params.md
@@ -81,7 +81,7 @@ Now that there are inputs in the action's metadata we can use the `@actions/core
 ```javascript
 const core = require("@actions/core");
 
-const firstGreeting = core.getInput("first-greeting"):
+const firstGreeting = core.getInput("first-greeting");
 const secondGreeting = core.getInput("second-greeting");
 const thirdGreeting = core.getInput("third-greeting");
 


### PR DESCRIPTION
Fix a syntax error in main.js in 07_add-input-params.md