### PR TITLE
Add repo-token as input to action.yml code example 

### DIFF
--- a/responses/14_create-metadata.md
+++ b/responses/14_create-metadata.md
@@ -42,6 +42,8 @@ We will use the joke output, an `issue-title`, and the `repo-token` in this port
         description: "Every issue needs a title, it's nice to supply one, even though you could do this dynamically within your code"
         default: "a joke for you"
         required: true
+      repo-token:
+        description: "Token with permissions to do repo things"
 
     runs:
       using: "node12"

--- a/responses/14_create-metadata.md
+++ b/responses/14_create-metadata.md
@@ -27,7 +27,7 @@ Now, we will do something similar so that our action matches what our workflow e
 
 💡All of the following steps take place inside of the `.github/actions/issue-maker` directory.
 
-We will use the `joke-output`, as well as an issue title, in in this portion of the course so we need to accept `inputs:` for our action.
+We will use the joke output, an `issue-title`, and the `repo-token` in this portion of the course as `inputs:` for our action.
 
 1. Create a file named `action.yml` with the following contents:
     ```yaml


### PR DESCRIPTION
This resolves #21 

> It looks like we're asking folks to use an action without updating the proper metadata first.
>
> This was reported in the community forum by @kopijunkie and can be added to responses/14_create-metadata.md.