### PR TITLE
Update Octokit API call to latest version

### DIFF
--- a/responses/14_create-js-files.md
+++ b/responses/14_create-js-files.md
@@ -108,7 +108,7 @@ async function run() {
 
     const octokit = github.getOctokit(token);
 
-    const newIssue = await octokit.issues.create({
+    const newIssue = await octokit.rest.issues.create({
         repo: github.context.repo.repo,
         owner: github.context.repo.owner,
         title: issueTitle,


### PR DESCRIPTION
Error: Cannot read property 'create' of undefined using "octokit.issues.create".

Based on Octokit API latest version (v18 - https://octokit.github.io/rest.js/v18?msclkid=1de4bc88ad1011ecb91b07acd993550f#issues), new way to call "octokit.rest.issues.create"